### PR TITLE
ditch ocean.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# pdr-publisher
+
+To deploy a predictoor contract, do:
+
+- set RPC_URL env
+- set PRIVATE_KEY env
+- edit deploy.py and set token names, symbols, epochs, etc..
+- install requirements
+- call "python3 deploy.py

--- a/deploy.py
+++ b/deploy.py
@@ -18,17 +18,36 @@ S_PER_MIN = 60
 S_PER_HOUR = 60 * 60
 MAX_UINT256 = 2**256 - 1
 # for our ganache, have one epoch per minute (every 60 blocks)
-s_per_block = 1  # depends on the chain
-s_per_epoch = 1 * S_PER_MIN
-s_per_subscription = 24 * S_PER_HOUR
-feeCollector = owner
-rate = web3_config.w3.to_wei(2,'ether')
+base = "ETH"
+quote = "USDT"
+source = "kraken"
+timeframe = '5m'
+pair = "ETH/USDT"
+
+
+
+s_per_block = 7  # depends on the chain
+s_per_epoch = 301
+s_per_subscription = 86394
+trueval_timeout = 4 * 12 * s_per_epoch
+
+print(f"{s_per_subscription % s_per_block}")
+print(f"{s_per_epoch % s_per_block}")
+
+
+feeCollector = web3_config.w3.to_checksum_address("0x4FF94e326DdA576132b0731333a62427f1611Ca9")
+trueval_submiter = web3_config.w3.to_checksum_address("0xAc69154e0C32C99863dA5f717D7D52f202C9A80D")
+rate = web3_config.w3.to_wei(3,'ether')
 cut = web3_config.w3.to_wei(0.2,'ether')
 
+nft_name = base+"-"+quote+"-"+source+"-"+timeframe
+nft_symbol = pair
+erc20_name = nft_symbol
+erc20_symbol = nft_symbol
 
 nft_data = (
-    "nft_name",
-    "nft_symbol",
+    nft_name,
+    nft_symbol,
     1,
     "",
     True,
@@ -36,15 +55,15 @@ nft_data = (
 )
 erc_data = (
     3,
-    ["ETH-USDT", "ETH-USDT"],
+    [erc20_name, erc20_symbol],
     [
         owner,
         owner,
-        owner,
+        feeCollector,
         ocean_address,
         ocean_address,
     ],
-    [MAX_UINT256, 0, s_per_block, s_per_epoch, s_per_subscription, 30],
+    [MAX_UINT256, 0, s_per_block, s_per_epoch, s_per_subscription, trueval_timeout],
     [],
 )
 fre_data = (
@@ -67,9 +86,19 @@ fre_data = (
 data_nft_address = factory.createNftWithErc20WithFixedRate(nft_data,erc_data,fre_data)
 print(f"Deployed NFT: {data_nft_address}")
 data_nft = DataNft(web3_config,data_nft_address)
-data_nft.set_data("pair", "ETH/USDT")
-
-ddo = {
-    "title": "aaa"
-}
-data_nft.set_ddo(ddo)
+tx = data_nft.set_data("pair", pair)
+print(f"Pait set to {pair} in {tx.hex()}")
+tx = data_nft.set_data("base", base)
+print(f"base set to {base} in {tx.hex()}")
+tx = data_nft.set_data("quote", quote)
+print(f"quote set to {quote} in {tx.hex()}")
+tx = data_nft.set_data("source", source)
+print(f"source set to {source} in {tx.hex()}")
+tx = data_nft.set_data("timeframe", timeframe)
+print(f"timeframe set to {timeframe} in {tx.hex()}")
+tx = data_nft.add_erc20_deployer(trueval_submiter)
+print(f"Erc20Deployer set to {trueval_submiter} in {tx.hex()}")
+#ddo = {
+#    "title": "aaa"
+#}
+#data_nft.set_ddo(ddo)

--- a/deploy.py
+++ b/deploy.py
@@ -1,0 +1,75 @@
+import time
+import os
+
+
+from utils.contract import DataNft,ERC721Factory, Web3Config, get_address
+
+# TODO - check for all envs
+assert os.environ.get("RPC_URL", None), "You must set RPC_URL environment variable"
+web3_config = Web3Config(os.environ.get("RPC_URL"), os.environ.get("PRIVATE_KEY"))
+owner = web3_config.owner
+ocean_address = get_address(web3_config.w3.eth.chain_id,"Ocean")
+fre_address = get_address(web3_config.w3.eth.chain_id,"FixedPrice")
+factory = ERC721Factory(web3_config)
+
+
+
+S_PER_MIN = 60
+S_PER_HOUR = 60 * 60
+MAX_UINT256 = 2**256 - 1
+# for our ganache, have one epoch per minute (every 60 blocks)
+s_per_block = 1  # depends on the chain
+s_per_epoch = 1 * S_PER_MIN
+s_per_subscription = 24 * S_PER_HOUR
+feeCollector = owner
+rate = web3_config.w3.to_wei(2,'ether')
+cut = web3_config.w3.to_wei(0.2,'ether')
+
+
+nft_data = (
+    "nft_name",
+    "nft_symbol",
+    1,
+    "",
+    True,
+    owner
+)
+erc_data = (
+    3,
+    ["ETH-USDT", "ETH-USDT"],
+    [
+        owner,
+        owner,
+        owner,
+        ocean_address,
+        ocean_address,
+    ],
+    [MAX_UINT256, 0, s_per_block, s_per_epoch, s_per_subscription, 30],
+    [],
+)
+fre_data = (
+    fre_address,
+    [ 
+        ocean_address,
+        owner,
+        feeCollector,
+        owner
+    ],
+    [
+        18,
+        18,
+        rate,
+        cut,
+        1
+    ]
+
+)
+data_nft_address = factory.createNftWithErc20WithFixedRate(nft_data,erc_data,fre_data)
+print(f"Deployed NFT: {data_nft_address}")
+data_nft = DataNft(web3_config,data_nft_address)
+data_nft.set_data("pair", "ETH/USDT")
+
+ddo = {
+    "title": "aaa"
+}
+data_nft.set_ddo(ddo)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+web3
+eth-account
+pathlib
+eth-keys
+ocean-contracts==2.0.0a2

--- a/utils/contract.py
+++ b/utils/contract.py
@@ -1,0 +1,174 @@
+import json
+import os
+import glob
+import time
+import hashlib
+
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+from eth_keys import KeyAPI
+from eth_keys.backends import NativeECCBackend
+
+from pathlib import Path
+from web3 import Web3, HTTPProvider, WebsocketProvider
+from web3.logs import STRICT, IGNORE, DISCARD, WARN
+
+from web3.middleware import construct_sign_and_send_raw_middleware
+from os.path import expanduser
+
+import artifacts  # noqa
+import addresses # noqa
+
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+keys = KeyAPI(NativeECCBackend)
+
+
+class Web3Config:
+    def __init__(self, rpc_url: str, private_key: str):
+        self.rpc_url = rpc_url
+
+        if rpc_url is None:
+            raise ValueError("You must set RPC_URL environment variable")
+
+        if private_key is None:
+            raise ValueError("You must set PRIVATE_KEY environment variable")
+
+        self.w3 = Web3(Web3.HTTPProvider(rpc_url))
+
+        if private_key is not None:
+            if not private_key.startswith("0x"):
+                raise ValueError("Private key must start with 0x hex prefix")
+            self.account: LocalAccount = Account.from_key(private_key)
+            self.owner = self.account.address
+            self.private_key = private_key
+#            self.w3.middleware_onion.add(
+#                construct_sign_and_send_raw_middleware(self.account)
+#            )
+
+class ERC721Factory:
+    def __init__(self, config: Web3Config,chain_id=None):
+        if not chain_id:
+            chain_id = config.w3.eth.chain_id
+        address = get_address(chain_id,"ERC721Factory")
+        if not address:
+            raise ValueError("Cannot figure out ERC721Factory address")
+        self.contract_address = config.w3.to_checksum_address(address)
+        self.contract_instance = config.w3.eth.contract(
+            address=config.w3.to_checksum_address(address),
+            abi=get_contract_abi("ERC721Factory"),
+        )
+        self.config = config
+    
+    def createNftWithErc20WithFixedRate(self,NftCreateData, ErcCreateData,FixedData):
+            gasPrice = self.config.w3.eth.gas_price
+            call_params = {
+                "from": self.config.owner,
+                "gasPrice": gasPrice,
+                #                    'nonce': self.config.w3.eth.get_transaction_count(self.config.owner),
+            }
+
+
+            tx = self.contract_instance.functions.createNftWithErc20WithFixedRate(
+                NftCreateData, ErcCreateData,FixedData
+            ).transact(call_params)
+            receipt = self.config.w3.eth.wait_for_transaction_receipt(tx)
+            #print(receipt)
+            logs = self.contract_instance.events.NFTCreated().process_receipt(receipt,errors=DISCARD)
+            return logs[0]['args']['newTokenAddress']
+
+class DataNft:
+    def __init__(self, config: Web3Config, address: str):
+        self.contract_address = config.w3.to_checksum_address(address)
+        self.contract_instance = config.w3.eth.contract(
+            address=config.w3.to_checksum_address(address),
+            abi=get_contract_abi("ERC721Template"),
+        )
+        self.config = config
+    
+    def set_data(self, field_label,field_value):
+        """Set key/value data via ERC725, with strings for key/value"""
+        field_label_hash = Web3.keccak(text=field_label)  # to keccak256 hash
+        field_value_bytes = field_value.encode()  # to array of bytes
+        tx = self.contract_instance.functions.setNewData(field_label_hash, field_value_bytes).transact({"from":self.config.owner})
+        return tx
+    
+    def set_ddo(self,ddo):
+        js = json.dumps(ddo)
+        stored_ddo=Web3.to_bytes(text=js)
+        tx = self.contract_instance.functions.setMetaData(
+            1,
+            '',
+            str(self.config.owner),
+            bytes([0]),
+            stored_ddo,
+            Web3.to_bytes(hexstr=hashlib.sha256(js.encode("utf-8")).hexdigest()),
+            []
+        ).transact({"from":self.config.owner})
+        print(tx)
+        return(tx)
+
+def get_address(chain_id,contract_name):
+        network = get_addresses(chain_id)
+        if not network:
+            raise ValueError(f"Cannot figure out {contract_name} address")
+        address = network.get(contract_name)
+        return address
+
+def get_addresses(chain_id):
+
+    address_filename = os.getenv("ADDRESS_FILE")
+    path = None
+    if address_filename:
+        path = Path(address_filename)
+    else:
+        path = Path(str(os.path.dirname(addresses.__file__))+"/address.json")
+    
+    if not path.exists():
+        raise TypeError("Cannot find address.json")
+
+    with open(path) as f:
+        data = json.load(f)
+    for name in data:
+        network = data[name]
+        if network['chainId']==chain_id:
+            return network
+    return None
+
+def get_contract_abi(contract_name):
+    """Returns the abi for a contract name."""
+    path = get_contract_filename(contract_name)
+
+    if not path.exists():
+        raise TypeError("Contract name does not exist in artifacts.")
+
+    with open(path) as f:
+        data = json.load(f)
+        return data["abi"]
+
+
+def get_contract_filename(contract_name):
+    """Returns abi for a contract."""
+    contract_basename = f"{contract_name}.json"
+
+    # first, try to find locally
+    address_filename = os.getenv("ADDRESS_FILE")
+    path = None
+    if address_filename:
+        address_dir = os.path.dirname(address_filename)
+        root_dir = os.path.join(address_dir, "..")
+        os.chdir(root_dir)
+        paths = glob.glob(f"**/{contract_basename}", recursive=True)
+        if paths:
+            assert len(paths) == 1, "had duplicates for {contract_basename}"
+            path = paths[0]
+            path = Path(path).expanduser().resolve()
+            assert (
+                path.exists()
+            ), f"Found path = '{path}' via glob, yet path.exists() is False"
+            return path
+    # didn't find locally, so use use artifacts lib
+    path = os.path.join(os.path.dirname(artifacts.__file__), "", contract_basename)
+    path = Path(path).expanduser().resolve()
+    if not path.exists():
+        raise TypeError(f"Contract '{contract_name}' not found in artifacts.")
+    return path


### PR DESCRIPTION
Changes proposed in this PR:

- deploy.py using web3.py for remote networks

 To deploy a predictoor contract, do:
 - set RPC_URL env
 - set PRIVATE_KEY env
 - edit deploy.py and set token names, symbols, epochs, etc..
 - install requirements
 - call "python3 deploy.py


